### PR TITLE
VRV-2498 - Added the current filepath to the load path so that we can…

### DIFF
--- a/src/osgPlugins/fbx/ReaderWriterFBX.cpp
+++ b/src/osgPlugins/fbx/ReaderWriterFBX.cpp
@@ -206,7 +206,9 @@ ReaderWriterFBX::readNode(const std::string& filenameInit,
             else
                 localOptions = new osgDB::Options();
             localOptions->setObjectCacheHint(osgDB::ReaderWriter::Options::CACHE_IMAGES);
-
+            //Add the current file path to the path list so external references with relative paths work correctly.
+            localOptions->getDatabasePathList().push_front(currentFilePath);
+            
             std::string filePath = osgDB::getFilePath(filename);
             FbxMaterialToOsgStateSet fbxMaterialToOsgStateSet(filePath, localOptions.get(), lightmapTextures);
 


### PR DESCRIPTION
… load external references that use relative paths.

https://jira.mak.com:8443/browse/VRV-2498?filter=10301